### PR TITLE
Add deploying without CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Roadtrip is a CLI Tool to deploy and host static sites on AWS S3 and CloudFront,
 and manage DNS records using Route53 (optional).
 
 <!-- toc -->
-* [💡 How it works](#-how-it-works)
-* [🕶 At a glance](#-at-a-glance)
-* [👩‍💻 Install & Deploy](#-install--deploy)
-* [📝 Configuration](#-configuration)
-* [🔭 Branch Previews](#-branch-previews)
-* [🔨 Command Reference](#-command-reference)
-* [Alternatives](#alternatives)
-* [License](#license)
-<!-- tocstop -->
+
+- [💡 How it works](#-how-it-works)
+- [🕶 At a glance](#-at-a-glance)
+- [👩‍💻 Install & Deploy](#-install--deploy)
+- [📝 Configuration](#-configuration)
+- [🔭 Branch Previews](#-branch-previews)
+- [🔨 Command Reference](#-command-reference)
+- [Alternatives](#alternatives)
+- [License](#license)
+  <!-- tocstop -->
 
 # 💡 How it works
 
@@ -99,6 +100,7 @@ Example:
   "domain": "example.com",
   "dir": "./build",
   "https": false,
+  "cdn": true,
   "indexFile": "index.html",
   "errorFile": "404.html",
   "cacheControl": {
@@ -109,10 +111,14 @@ Example:
 
 #### name
 
+Type: `String`
+
 The name of your project. This will be the bucket's name. Can be overridden with
 the `--name` flag.
 
 #### domain
+
+Type: `String`
 
 A custom domain which will be added as alias to CloudFront. This allows you to
 add the CloudFront domain as CNAME to your domain.
@@ -130,12 +136,14 @@ automatically be added to the hosted zone for your domain.
 
 #### dir
 
+Type: `String`  
 Default: `.`
 
 The directory to sync with the bucket.
 
 #### https
 
+Type: `Boolean`  
 Default: `false`
 
 Use `true` to enable https. If you use a custom domain, you must have a valid
@@ -150,20 +158,32 @@ You can also use a wildcard certificate, e.g. for different environments on
 subdomains. Remember that a wildcard is only valid for one domain level.  
 Example: `*.example.com` works with `foo.example.com`, but not with `foo.bar.example.com`
 
+#### cdn
+
+Type: `Boolean`  
+Default: `true`
+
+Set this to `false` won't create a CloudFront distribution. You can still access
+your site with the S3 bucket's domain and use this domain as CNAME for a custom
+domain.
+
 #### indexFile
 
+Type: `String`  
 Default: `index.html`
 
 The file which will act as index page.
 
 #### errorFile
 
+Type: `String`  
 Default: `404.html`
 
 The file which will act as 404 page.
 
 #### cacheControl
 
+Type: `Object`  
 Default: `{}`
 
 Allows to add custom `Cache-Control` headers to the bucket's files using glob
@@ -213,33 +233,35 @@ $ roadtrip project:deploy --name=example-project-${BRANCH_NAME}
 ```
 
 Keep in mind that CloudFront needs ~10 minutes to roll out new distributions, so
-your branch preview won't be available immediately.  
-If you want a preview without this delay, you could have some environments
-already set-up.
+your branch preview won't be available immediately. If you want a preview
+without this delay, you can:
 
-You can also use a custom domain:
+- Have some environments already set-up.
+- Don't use CloudFront (which also means you can't use https).
 
 ```sh
 $ roadtrip project:deploy \
   --name=example-project-${BRANCH_NAME} \
   --domain=preview-${BRANCH_NAME}.example.com \
+  --skipCDN
   --connectDomain
 ```
 
 # 🔨 Command Reference
 
 <!-- commands -->
-* [`roadtrip autocomplete [SHELL]`](#roadtrip-autocomplete-shell)
-* [`roadtrip bucket:create`](#roadtrip-bucketcreate)
-* [`roadtrip bucket:setup`](#roadtrip-bucketsetup)
-* [`roadtrip bucket:sync`](#roadtrip-bucketsync)
-* [`roadtrip bucket:website`](#roadtrip-bucketwebsite)
-* [`roadtrip distribution:create`](#roadtrip-distributioncreate)
-* [`roadtrip distribution:invalidate`](#roadtrip-distributioninvalidate)
-* [`roadtrip domain:connect ALIAS`](#roadtrip-domainconnect-alias)
-* [`roadtrip help [COMMAND]`](#roadtrip-help-command)
-* [`roadtrip project:deploy`](#roadtrip-projectdeploy)
-* [`roadtrip update [CHANNEL]`](#roadtrip-update-channel)
+
+- [`roadtrip autocomplete [SHELL]`](#roadtrip-autocomplete-shell)
+- [`roadtrip bucket:create`](#roadtrip-bucketcreate)
+- [`roadtrip bucket:setup`](#roadtrip-bucketsetup)
+- [`roadtrip bucket:sync`](#roadtrip-bucketsync)
+- [`roadtrip bucket:website`](#roadtrip-bucketwebsite)
+- [`roadtrip distribution:create`](#roadtrip-distributioncreate)
+- [`roadtrip distribution:invalidate`](#roadtrip-distributioninvalidate)
+- [`roadtrip domain:connect ALIAS`](#roadtrip-domainconnect-alias)
+- [`roadtrip help [COMMAND]`](#roadtrip-help-command)
+- [`roadtrip project:deploy`](#roadtrip-projectdeploy)
+- [`roadtrip update [CHANNEL]`](#roadtrip-update-channel)
 
 ## `roadtrip autocomplete [SHELL]`
 
@@ -356,7 +378,7 @@ OPTIONS
   --[no-]https         set up the site with https
 
 DESCRIPTION
-  Creates a distribution and connects it to the S3 bucket of the site. If the distribution already exists, the 
+  Creates a distribution and connects it to the S3 bucket of the site. If the distribution already exists, the
   configuration will be updated.
   It looks for a matching certificate in the Certificate Manager. If no Certificate is found, it exits with an error.
 ```
@@ -398,7 +420,7 @@ OPTIONS
   --[no-]https         set up the site with https
 
 DESCRIPTION
-  Creates a record pointing to the CloudFront URL as an alias. If the record doesn't exist or the alias is wrong, it 
+  Creates a record pointing to the CloudFront URL as an alias. If the record doesn't exist or the alias is wrong, it
   will be updated.
 ```
 
@@ -437,7 +459,7 @@ OPTIONS
   --[no-]https         set up the site with https
 
 DESCRIPTION
-  Creates a bucket and uploads files onto it. Creates and configures a CloudFront distribution and links it to your 
+  Creates a bucket and uploads files onto it. Creates and configures a CloudFront distribution and links it to your
   domain.
   This task is idempotent. You can run it again to update the site.
 ```
@@ -454,6 +476,7 @@ USAGE
 ```
 
 _See code: [@oclif/plugin-update](https://github.com/oclif/plugin-update/blob/v1.3.9/src/commands/update.ts)_
+
 <!-- commandsstop -->
 
 # Alternatives

--- a/src/cli/bucket/sync.js
+++ b/src/cli/bucket/sync.js
@@ -3,7 +3,8 @@ import * as bucket from '../../tasks/bucket'
 
 export default class BucketSyncCommand extends TripCommand {
   async run() {
-    await this.runTasks([bucket.sync])
+    const ctx = await this.runTasks([bucket.sync])
+    this.log(`=> S3 bucket domain: ${ctx.bucketDomainName}`)
   }
 }
 

--- a/src/command.js
+++ b/src/command.js
@@ -22,6 +22,7 @@ export default class TripCommand extends OclifCommand {
       indexFile: 'index.html',
       errorFile: '404.html',
       cacheControl: {},
+      cdn: true,
       ...this.rawTripConfig,
       projectDir: path.resolve(fullConfigPath, '..'),
       name: flags.name || this.rawTripConfig.name,

--- a/src/lib/cloudfront.js
+++ b/src/lib/cloudfront.js
@@ -99,8 +99,7 @@ async function setDistributionIdToBucket(projectName, id) {
 }
 
 async function createConfig({ projectName, domain, certARN, https }) {
-  const region = await s3.getRegion(projectName)
-  const bucketDomain = `${projectName}.s3-website.${region}.amazonaws.com`
+  const bucketDomain = await s3.getDomain(projectName)
 
   // dear aws, this is madness.
   const config = {

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -118,6 +118,11 @@ export async function getRegion(projectName) {
   return region || 'us-east-1' // aws returns an empty string if region is us-east-1
 }
 
+export async function getDomain(projectName) {
+  const region = await getRegion(projectName)
+  return `${projectName}.s3-website.${region}.amazonaws.com`
+}
+
 export async function getCacheHash(projectName) {
   const value = await getTag(projectName, BUCKET_CACHE_TAG)
   return value

--- a/src/tasks/bucket.js
+++ b/src/tasks/bucket.js
@@ -32,7 +32,9 @@ export const website = {
       indexFile,
       errorFile
     })
-    return s3.website(ctx.trip.name, { indexFile, errorFile })
+    await s3.website(ctx.trip.name, { indexFile, errorFile })
+    const bucketDomain = await s3.getDomain(ctx.trip.name)
+    ctx.bucketDomainName = bucketDomain
   }
 }
 

--- a/src/tasks/domain.js
+++ b/src/tasks/domain.js
@@ -6,7 +6,8 @@ export const connect = {
   title: 'Connect dns entry',
   task: async (ctx, task) => {
     task.output = 'Checking if record exists...'
-    const exists = await r53.exists(ctx.trip.name, ctx.cloudfrontDomainName)
+    const alias = ctx.cloudfrontDomainName || ctx.bucketDomainName
+    const exists = await r53.exists(ctx.trip.name, alias)
     debug('Record exists and is correct: %s', exists)
 
     if (exists) {
@@ -15,7 +16,7 @@ export const connect = {
     }
 
     task.output = 'Insert/update dns record...'
-    debug('Upsert record: %s ALIAS %s', ctx.trip.name, ctx.cloudfrontDomainName)
-    return r53.upsert(ctx.trip.name, ctx.cloudfrontDomainName)
+    debug('Upsert record: %s ALIAS %s', ctx.trip.name, alias)
+    return r53.upsert(ctx.trip.name, alias)
   }
 }


### PR DESCRIPTION
Adds `cdn` to `roundtrip.json`, and also the `--skipCDN` flag. Both will skip all CloudFront-related tasks.

Closes #5 